### PR TITLE
Uncap vertical weapon arcs

### DIFF
--- a/server/paper/src/main/kotlin/net/stellarica/server/crafts/starships/subsystems/weapons/WeaponSubsystem.kt
+++ b/server/paper/src/main/kotlin/net/stellarica/server/crafts/starships/subsystems/weapons/WeaponSubsystem.kt
@@ -54,7 +54,7 @@ class WeaponSubsystem(ship: Starship) : Subsystem(ship) {
 					val eyePitch = asin(-eye.y)
 					val eyeYaw = atan2(eye.x, eye.z)
 
-					val pitch = eyePitch /*.coerceIn(dirPitch - type.cone, dirPitch + type.cone) */ //this check had been seized by the balancing department
+					val pitch = eyePitch // .coerceIn(dirPitch - type.cone, dirPitch + type.cone)  //this check had been seized by the balancing department
 					val yaw = if (eyeYaw - type.cone > -PI) {
 						eyeYaw.coerceIn(dirYaw - type.cone, dirYaw + type.cone)
 					} else { // fix for atan2 range not going beneath -PI, breaking coerceIn

--- a/server/paper/src/main/kotlin/net/stellarica/server/crafts/starships/subsystems/weapons/WeaponSubsystem.kt
+++ b/server/paper/src/main/kotlin/net/stellarica/server/crafts/starships/subsystems/weapons/WeaponSubsystem.kt
@@ -54,7 +54,7 @@ class WeaponSubsystem(ship: Starship) : Subsystem(ship) {
 					val eyePitch = asin(-eye.y)
 					val eyeYaw = atan2(eye.x, eye.z)
 
-					val pitch = eyePitch.coerceIn(dirPitch - type.cone, dirPitch + type.cone)
+					val pitch = eyePitch /*.coerceIn(dirPitch - type.cone, dirPitch + type.cone) */ //this check had been seized by the balancing department
 					val yaw = if (eyeYaw - type.cone > -PI) {
 						eyeYaw.coerceIn(dirYaw - type.cone, dirYaw + type.cone)
 					} else { // fix for atan2 range not going beneath -PI, breaking coerceIn


### PR DESCRIPTION
Since there is no way to rotate the ship nose-down to shoot targets below i can see this change fit. You still can't shoot directly up but that's a question for another time